### PR TITLE
fix: Skip if paths not defined

### DIFF
--- a/bridgetown.automation.rb
+++ b/bridgetown.automation.rb
@@ -72,6 +72,9 @@ create_builder "tailwind_jit.rb" do
     class Builders::TailwindJit < SiteBuilder
       def build
         hook :site, :pre_reload do |_, paths|
+          # Skip if path are not defined (e.g: from console reload)
+          next unless paths
+
           # Don't trigger refresh if it's a frontend-only change
           next if paths.length == 1 && paths.first.ends_with?("manifest.json")
 

--- a/bridgetown.automation.rb
+++ b/bridgetown.automation.rb
@@ -72,7 +72,7 @@ create_builder "tailwind_jit.rb" do
     class Builders::TailwindJit < SiteBuilder
       def build
         hook :site, :pre_reload do |_, paths|
-          # Skip if path are not defined (e.g: from console reload)
+          # Skip if paths are not defined (e.g: from console reload)
           next unless paths
 
           # Don't trigger refresh if it's a frontend-only change


### PR DESCRIPTION
The TailwindJit builder was causing a problem in the console while running `reload!`.

Specifically:
```
undefined method `length' for nil:NilClass (NoMethodError)
```

Checking the existence of `paths` solved the issue.