### PR TITLE
Lock tailwind version to 3

### DIFF
--- a/bridgetown.automation.rb
+++ b/bridgetown.automation.rb
@@ -5,7 +5,7 @@ say_status :tailwind, "Installing Tailwind CSS..."
 confirm = ask "This configuration will ovewrite your existing #{"postcss.config.js".bold.white}. Would you like to continue? [Yn]"
 return unless confirm.casecmp?("Y")
 
-run "yarn add -D tailwindcss"
+run "yarn add -D tailwindcss@3"
 run "npx tailwindcss init"
 
 gsub_file "tailwind.config.js", "content: [],", <<~JS.strip


### PR DESCRIPTION
It seems that Tailwind 4 does not support `init` command. In order to make this automation work, we have to lock It's version to 3 as otherwise it installs v4 and entire automation breaks.