### PR TITLE
Update for TailwindCSS v4

### DIFF
--- a/bridgetown.automation.rb
+++ b/bridgetown.automation.rb
@@ -5,26 +5,18 @@ say_status :tailwind, "Installing Tailwind CSS..."
 confirm = ask "This configuration will ovewrite your existing #{"postcss.config.js".bold.white}. Would you like to continue? [Yn]"
 return unless confirm.casecmp?("Y")
 
-run "yarn add -D tailwindcss"
-run "npx tailwindcss init"
-
-gsub_file "tailwind.config.js", "content: [],", <<~JS.strip
-  content: [
-      './src/**/*.{html,md,liquid,erb,serb,rb}',
-      './frontend/javascript/**/*.js',
-    ],
-JS
+run "npm install tailwindcss @tailwindcss/postcss --save-dev"
 
 create_file "postcss.config.js", <<~JS, force: true
-  module.exports = {
+  export default {
     plugins: {
-      'tailwindcss': {},
+      '@tailwindcss/postcss': {},
       'postcss-flexbugs-fixes': {},
       'postcss-preset-env': {
         autoprefixer: {
           flexbox: 'no-2009'
         },
-        stage: 2
+        stage: 3
       }
     }
   }
@@ -36,9 +28,7 @@ css_imports = <<~CSS
   @import "jit-refresh.css"; /* triggers frontend rebuilds */
 
   /* Set up Tailwind imports */
-  @tailwind base;
-  @tailwind components;
-  @tailwind utilities;
+  @import "tailwindcss";
 
 CSS
 


### PR DESCRIPTION
Updates this automation to make it work for TailwindCSS v4, the current code will break since it's only for Tailwind CSS v3

Not sure how much backwards compatability we want to keep around but this new code will work with TailwindCSS v4.

I'm not too sure if we still need `jit_refresh.css` or not since I can't get it to work on `v2.0.0.beta4`