### PR TITLE
Improve Tailwind CSS automation setup and configuration to work seemlessly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,21 @@ In your Bridgetown project folder, run:
 bin/bridgetown apply https://github.com/bridgetownrb/tailwindcss-automation
 ```
 
-(Note: it will overwrite any existing `postcss.config.js` file in your repo.)
-
 You can also apply the automation when creating a new site:
 
 ```
 bridgetown new mysite --apply=https://github.com/bridgetownrb/tailwindcss-automation
 ```
 
-The automation will add Tailwind to your `package.json`, set up a default Tailwind config, add the import statements to your frontend CSS entrypoint, and add a builder which will detect when content in `src` is modified and trigger Tailwind's JIT compiler to run.
+The automation will install `tailwindcss` and `@tailwindcss/cli`, create `frontend/styles/tailwind.css` with the recommended `@import` and `@source` directives, wire Tailwind into your frontend bundling manifest, and add a `bin/tailwindcss` helper for building and watching.
+
+During `frontend:build`, the `bin/tailwindcss` helper runs the Tailwind CLI, then fingerprints the generated CSS and updates the Bridgetown manifest entry for `styles/tailwind.css`. During `frontend:watch`, the helper runs Tailwind in watch mode.
+
+To load the stylesheet in your templates, use:
+
+```
+<%= asset_path "styles/tailwind.css" %>
+```
 
 Any questions? [Check out the Bridgetown community discussion channels for help.](https://www.bridgetownrb.com/community)
 

--- a/bridgetown.automation.rb
+++ b/bridgetown.automation.rb
@@ -2,86 +2,43 @@
 
 say_status :tailwind, "Installing Tailwind CSS..."
 
-confirm = ask "This configuration will ovewrite your existing #{"postcss.config.js".bold.white}. Would you like to continue? [Yn]"
-return unless confirm.casecmp?("Y")
-
-run "npm install tailwindcss @tailwindcss/postcss --save-dev"
-
-create_file "postcss.config.js", <<~JS, force: true
-  export default {
-    plugins: {
-      '@tailwindcss/postcss': {},
-      'postcss-flexbugs-fixes': {},
-      'postcss-preset-env': {
-        autoprefixer: {
-          flexbox: 'no-2009'
-        },
-        stage: 3
-      }
-    }
-  }
-JS
+run "npm install tailwindcss @tailwindcss/cli --save-dev"
 
 css_imports = <<~CSS
-  /* If you need to add @import statements, do so up here */
-
-  @import "jit-refresh.css"; /* triggers frontend rebuilds */
-
-  /* Set up Tailwind imports */
-  @import "tailwindcss";
-
+  @import 'tailwindcss' source(none);
+  @source '../';
+  @source '../../config';
+  @source '../../plugins';
+  @source '../../src';
 CSS
 
-if File.exist?("frontend/styles/index.css")
-  prepend_to_file "frontend/styles/index.css", css_imports
-else
-  say "\nPlease add the following lines to your CSS index file:"
-  say css_imports
-end
-
-create_file "frontend/styles/jit-refresh.css", "/* #{Time.now.to_i} */"
+create_file "frontend/styles/tailwind.css", css_imports
 
 insert_into_file "Rakefile",
-                  after: %r{  task :(build|dev) do\n} do
-  <<-JS
-    sh "touch frontend/styles/jit-refresh.css"
-  JS
+                  after: %r{  task :(build) do\n} do
+  <<-RUBY
+    sh "bin/tailwindcss"
+  RUBY
 end
 
-if File.exist?(".gitignore")
-  append_to_file ".gitignore" do
-    <<~FILES
-
-      frontend/styles/jit-refresh.css
-    FILES
-  end
-end
-
-create_builder "tailwind_jit.rb" do
-  <<~'RUBY'
-    class Builders::TailwindJit < SiteBuilder
-      def build
-        return if ARGV.include?("--skip-tw-jit")
-
-        fast_refreshing = false
-
-        hook :site, :fast_refresh do
-          fast_refreshing = true
-        end
-
-        hook :site, :post_write do
-          if fast_refreshing
-            fast_refreshing = false
-            Thread.new do
-              sleep 0.75
-              refresh_file = site.in_root_dir("frontend", "styles", "jit-refresh.css")
-              File.write refresh_file, "/* #{Time.now.to_i} */"
-            end
-          end
-        end
-      end
+append_to_file "Rakefile" do
+  <<~RUBY
+    Rake::Task['frontend:watcher'].enhance do
+      Bridgetown::Utils::Aux.run_process(
+        'Tailwind',
+        :blue,
+        'bin/tailwindcss --watch'
+      )
     end
   RUBY
 end
 
+get "#{__dir__}/tailwindcss", "bin/tailwindcss"
+chmod "bin/tailwindcss", 0755
+
+gsub_file 'config/esbuild.defaults.js', /const manifest = {/ do |match|
+  match << ' "styles/tailwind.css":"tailwind.css" '
+end
+
 say_status :tailwind, "Tailwind CSS is now configured."
+say_status :tailwind, 'Use `asset_path "styles/tailwind.css"` in your templates to load the CSS file.'

--- a/tailwindcss
+++ b/tailwindcss
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'base64'
+require 'digest'
+require 'json'
+
+root = Dir.pwd
+input_path = File.join(root, 'frontend', 'styles', 'tailwind.css')
+output_dir = File.join(root, 'output', '_bridgetown', 'static')
+temp_output_path = File.join(output_dir, 'tailwind.css')
+manifest_path = File.join(root, '.bridgetown-cache', 'frontend-bundling', 'manifest.json')
+manifest_key = 'styles/tailwind.css'
+
+should_watch = ARGV.include?('--watch')
+
+def update_manifest(manifest_path, key, value)
+  manifest = JSON.parse(File.read(manifest_path))
+  manifest[key] = value
+  File.write(manifest_path, JSON.generate(manifest))
+end
+
+def fingerprint_css(temp_output_path, output_dir)
+  css = File.read(temp_output_path)
+  digest = Digest::SHA256.digest(css)
+  fingerprint = Base64.urlsafe_encode64(digest).delete('=').upcase[0, 8]
+  name = "tailwind.#{fingerprint}.css"
+  path = File.join(output_dir, name)
+  File.write(path, css)
+  name
+end
+
+tailwind_cli = File.join(root, 'node_modules', '@tailwindcss', 'cli', 'dist', 'index.mjs')
+unless File.exist?(tailwind_cli)
+  warn 'tailwindcss CLI not found; install @tailwindcss/cli'
+  exit 1
+end
+
+tailwind_args = [tailwind_cli, '-i', input_path, '-o', temp_output_path]
+tailwind_args << '--watch' if should_watch
+
+pid = Process.spawn('node', *tailwind_args, out: $stdout, err: $stderr)
+Process.wait(pid)
+exit_status = $?.exitstatus
+
+exit exit_status if should_watch
+
+if exit_status == 0
+  if File.exist?(temp_output_path)
+    name = fingerprint_css(temp_output_path, output_dir)
+    update_manifest(manifest_path, manifest_key, name)
+    puts "tailwind: fingerprinted -> #{name}"
+  else
+    warn 'tailwind: output css not found, skipping fingerprint'
+  end
+else
+  exit exit_status
+end


### PR DESCRIPTION
It no longer relies on the JIT builder which caused multiple reloads, destroyed fast refreshing, etc

Additionally, if people want to use the default CSS with this, they can without issues.